### PR TITLE
TEL-4440 Adds missing parameter

### DIFF
--- a/src/emit_heartbeat_metric.py
+++ b/src/emit_heartbeat_metric.py
@@ -4,7 +4,7 @@ import os
 import graphyte
 
 
-def lambda_handler(event):
+def lambda_handler(event, context):
     graphite_host = os.getenv("GRAPHITE_HOST", "graphite-collectd")
     graphite_metric_prefix = os.getenv("GRAPHITE_METRIC_PREFIX", "container-insights")
 


### PR DESCRIPTION
What did we do?
--

1. I had removed this parameter, turns out I need it

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4440

Evidence of work
--

1. error `"errorMessage": "lambda_handler() takes 1 positional argument but 2 were given",`

Next Steps
--

1. Rollout in lab +test

Risks
--

1. I can't tweak the code in the Lambda console because it's too large
