### PR TITLE
TEL-4440 Sets metric path to match alert simulator

### DIFF
--- a/src/emit_heartbeat_metric.py
+++ b/src/emit_heartbeat_metric.py
@@ -6,7 +6,7 @@ import graphyte
 
 def lambda_handler(event, context):
     graphite_host = os.getenv("GRAPHITE_HOST", "graphite-collectd")
-    graphite_metric_prefix = os.getenv("GRAPHITE_METRIC_PREFIX", "container-insights")
+    graphite_metric_prefix = os.getenv("GRAPHITE_METRIC_PREFIX", "telemetry")
 
     current_time = datetime.datetime.now()
     minutes = current_time.minute
@@ -17,7 +17,7 @@ def lambda_handler(event, context):
 
     graphyte.init(host=graphite_host, prefix=graphite_metric_prefix, timeout=1)
     graphyte.send(
-        metric="foo.bar",
+        metric="metrics.alerting.heartbeat",
         value=val,
         timestamp=current_time.timestamp(),
     )


### PR DESCRIPTION
What did we do?
--

1. We discussed with the team and are happy for this to have the same path as the flip-flop metric that alert-simulator generates

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-4440
